### PR TITLE
Fix memory allocation for SampleObject

### DIFF
--- a/src/coloreddbg.cc
+++ b/src/coloreddbg.cc
@@ -116,8 +116,7 @@ build_main ( BuildOpts& opt )
 
 
 	// Allocate QF structs for input CQFs
-	inobjects = (SampleObject<CQF<KeyObject>*>*)calloc(MAX_NUM_SAMPLES,
-																	sizeof(SampleObject<CQF<KeyObject>*>));
+	inobjects = new SampleObject<CQF<KeyObject>*>[MAX_NUM_SAMPLES];
 	cqfs = (CQF<KeyObject>*)calloc(MAX_NUM_SAMPLES, sizeof(CQF<KeyObject>));
 
 	// Read cutoffs files


### PR DESCRIPTION
Hi,

This error caused me major headache. I am not sure what exactly is different on my system, but I kept getting segfaults in build_main.

Unfortunately I don't know nearly enough about c++ to tell what consequences this fix has, but for me mantis works after changing from `calloc` to `new`.

My best guess is that the operator= at line 144:

```
inobjects[nqf] = SampleObject<CQF<KeyObject>*>(&cqfs[nqf], sample_id, nqf);
```

cannot be used on zero-initialized memory, and instead something like `memcpy()` should be used. I opted for the c++ method instead.

I hope this is of any help. I am certainly glad that I finally got this very cool project to work and will test it out in the next days. Thanks for sharing it :-).

Cheers