### PR TITLE
Use pkg-config with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ if (NOT CMAKE_BUILD_TYPE)
    set (CMAKE_BUILD_TYPE "Release")
 endif()
 
+# Use pkg-config if present
+find_package(PkgConfig)
+
 # We require C++17
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -32,6 +35,14 @@ set(MANTIS_C_WARN "-Wno-unused-result;-Wno-strict-aliasing;-Wno-unused-function;
 set(MANTIS_CXX_WARN "-Wno-unused-result;-Wno-strict-aliasing;-Wno-unused-function;-Wno-sign-compare")
 set(MANTIS_C_FLAGS "${ARCH_DEFS};${MANTIS_C_WARN}")
 set(MANTIS_CXX_FLAGS "${ARCH_DEFS};${MANTIS_CXX_WARN}")
+
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules(SDSL sdsl-lite)
+  if (SDSL_FOUND)
+    list(APPEND MANTIS_CXX_FLAGS ${SDSL_CFLAGS})
+    list(APPEND LINK_FLAGS ${SDSL_LDFLAGS})
+  endif()
+endif()
 
 if (SDSL_INSTALL_PATH)
    message("Adding ${SDSL_INSTALL_PATH}/include to the include path")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,10 @@ target_compile_definitions(mantis PUBLIC "${ARCH_DEFS}")
 #target_link_libraries(estimateNumOfKners mantis_core)
 
 # TODO: look more into why this is necessary
+if (SDSL_FOUND)
+  set_property(TARGET mantis APPEND PROPERTY LINK_DIRECTORIES ${SDSL_LIBRARY_DIRS})
+  set_property(TARGET mantis APPEND PROPERTY LINK_LIBRARIES ${SDSL_LINK_LIBRARIES})
+endif()
 if (SDSL_INSTALL_PATH)
    set_property(TARGET mantis APPEND_STRING PROPERTY LINK_FLAGS "-L${SDSL_INSTALL_PATH}/lib")
    set_property(TARGET mantis_core APPEND_STRING PROPERTY LINK_FLAGS "-L${SDSL_INSTALL_PATH}/lib")

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -293,4 +293,6 @@ int stats_main(StatsOpts &sopt) {
         logger->info("total confused kmers: {}", kmerMap.size());
         logger->info("total non-confusing jmers: {}", jmerMap.size());
     }
+
+    return 0;
 }

--- a/src/validateMST.cc
+++ b/src/validateMST.cc
@@ -108,4 +108,5 @@ int validate_mst_main(MSTValidateOpts &opt) {
         }
     }
     logger->info("\nWOOOOW! Validation passed\n");
+    return 0;
 }


### PR DESCRIPTION
* Detect if pkg-config is available on the system. If so look for `sdsl-lite` using pkg-config. Configures CXXFLAGS and linker flags (LIBRARY_DIRS and LINK_LIBRARIES) from pkg-config information

* Add `return 0` at the end of 2 sub-main function to avoid warning.